### PR TITLE
feature/grace seconds

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -95,7 +95,7 @@ func (a *Alert) shouldAlert() bool {
 		return false
 	}
 	t := NewThrottler()
-	return !t.IsThrottled(a.Error)
+	return !t.IsThrottledOrGraced(a.Error)
 }
 
 func (a *Alert) isDoNotAlert() bool {

--- a/alert_test.go
+++ b/alert_test.go
@@ -182,7 +182,7 @@ func TestAlert_shouldAlert(t *testing.T) {
 				os.Setenv("THROTTLE_ENABLED", "false")
 			}
 			if tt.name == "shouldAlert_graced_false" {
-				os.Setenv("GRACE_DURATION", "20")
+				os.Setenv("THROTTLE_GRACE_SECONDS", "20")
 			}
 			a := &Alert{
 				Error:            tt.fields.Error,

--- a/alert_test.go
+++ b/alert_test.go
@@ -159,6 +159,14 @@ func TestAlert_shouldAlert(t *testing.T) {
 			},
 			want: true,
 		},
+		{name: "shouldAlert_graced_false",
+			fields: fields{
+				Error: errors.New("alert this"),
+				DoNotAlertErrors: []error{
+					errors.New("do not alert"), errors.New("if this error then don't alert")},
+			},
+			want: false,
+		},
 		{name: "shouldAlert_true_disable_throttling",
 			fields: fields{
 				Error: errors.New("do not alert"),
@@ -173,6 +181,9 @@ func TestAlert_shouldAlert(t *testing.T) {
 			if tt.name == "shouldAlert_true_disable_throttling" {
 				os.Setenv("THROTTLE_ENABLED", "false")
 			}
+			if tt.name == "shouldAlert_graced_false" {
+				os.Setenv("GRACE_DURATION", "20")
+			}
 			a := &Alert{
 				Error:            tt.fields.Error,
 				DoNotAlertErrors: tt.fields.DoNotAlertErrors,
@@ -180,7 +191,8 @@ func TestAlert_shouldAlert(t *testing.T) {
 			if err := a.RemoveCurrentThrotting(); err != nil {
 				t.Errorf("Alert.Notify() error = %+v", err)
 			}
-			if got := a.shouldAlert(); got != tt.want {
+			got := a.shouldAlert()
+			if got != tt.want {
 				t.Errorf("Alert.shouldAlert() = %v, want %v", got, tt.want)
 			}
 		})

--- a/throttler.go
+++ b/throttler.go
@@ -124,7 +124,10 @@ func (t *Throttler) InitGrace(errObj error) []byte {
 	now := time.Now().Format(time.RFC3339)
 	cachedDetectionTime := []byte(now)
 	err = dc.Set(fmt.Sprintf("%v_detectionTime", errObj.Error()), cachedDetectionTime)
-	return cachedDetectionTime
+	if err == nil {
+		return cachedDetectionTime
+	}
+	return nil
 }
 
 // CleanThrottlingCache clean all the diskcache in throttling cache directory

--- a/throttler_test.go
+++ b/throttler_test.go
@@ -21,6 +21,7 @@ func TestNewThrottler(t *testing.T) {
 			want: Throttler{
 				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
 				ThrottleDuration: 5,
+				GraceDuration:    0,
 			},
 		},
 		{
@@ -28,6 +29,7 @@ func TestNewThrottler(t *testing.T) {
 			want: Throttler{
 				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
 				ThrottleDuration: 7,
+				GraceDuration:    5,
 			},
 		},
 		{
@@ -35,28 +37,33 @@ func TestNewThrottler(t *testing.T) {
 			want: Throttler{
 				CacheOpt:         "new_cache_dir",
 				ThrottleDuration: 8,
+				GraceDuration:    0,
 			},
 		},
 	}
 	for _, tt := range tests {
 		if tt.name == "change duration" {
 			os.Setenv("THROTTLE_DURATION", "7")
+			os.Setenv("GRACE_DURATION", "5")
 		} else if tt.name == "change both" {
 			os.Setenv("THROTTLE_DURATION", "8")
+			os.Setenv("GRACE_DURATION", "0")
 			os.Setenv("THROTTLE_DISKCACHE_DIR", "new_cache_dir")
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewThrottler(); !reflect.DeepEqual(got, tt.want) {
+			got := NewThrottler()
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewThrottler() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestThrottler_IsThrottled(t *testing.T) {
+func TestThrottler_IsThrottledOrGraced(t *testing.T) {
 	type fields struct {
 		CacheOpt         string
 		ThrottleDuration int
+		GraceDuration    int
 	}
 	type args struct {
 		ocError error
@@ -72,6 +79,7 @@ func TestThrottler_IsThrottled(t *testing.T) {
 			fields: fields{
 				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
 				ThrottleDuration: 5,
+				GraceDuration:    0,
 			},
 			args: args{
 				ocError: errors.New("test_throttling"),
@@ -83,6 +91,19 @@ func TestThrottler_IsThrottled(t *testing.T) {
 			fields: fields{
 				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
 				ThrottleDuration: 5,
+				GraceDuration:    0,
+			},
+			args: args{
+				ocError: errors.New("test_throttling"),
+			},
+			want: true,
+		},
+		{
+			name: "graced_true",
+			fields: fields{
+				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
+				ThrottleDuration: 5,
+				GraceDuration:    25,
 			},
 			args: args{
 				ocError: errors.New("test_throttling"),
@@ -95,14 +116,14 @@ func TestThrottler_IsThrottled(t *testing.T) {
 			th := &Throttler{
 				CacheOpt:         tt.fields.CacheOpt,
 				ThrottleDuration: tt.fields.ThrottleDuration,
+				GraceDuration:    tt.fields.GraceDuration,
 			}
 			if tt.name == "throttled_true" {
 				if err := th.ThrottleError(tt.args.ocError); err != nil {
 					t.Errorf("testing failed : %+v", err)
 				}
-
 			}
-			if got := th.IsThrottled(tt.args.ocError); got != tt.want {
+			if got := th.IsThrottledOrGraced(tt.args.ocError); got != tt.want {
 				t.Errorf("Throttler.IsThrottled() = %v, want %v", got, tt.want)
 			}
 			err := th.CleanThrottlingCache()
@@ -118,6 +139,7 @@ func TestThrottler_ThrottleError(t *testing.T) {
 	type fields struct {
 		CacheOpt         string
 		ThrottleDuration int
+		GraceDuration    int
 	}
 	type args struct {
 		errObj error
@@ -133,6 +155,7 @@ func TestThrottler_ThrottleError(t *testing.T) {
 			fields: fields{
 				CacheOpt:         fmt.Sprintf("/tmp/cache/%v_throttler_disk_cache", os.Getenv("APP_NAME")),
 				ThrottleDuration: 5,
+				GraceDuration:    0,
 			},
 			args: args{
 				errObj: errors.New("test_throttling"),
@@ -144,6 +167,7 @@ func TestThrottler_ThrottleError(t *testing.T) {
 			fields: fields{
 				CacheOpt:         "/no_permission_dir",
 				ThrottleDuration: 5,
+				GraceDuration:    0,
 			},
 			args: args{
 				errObj: errors.New("test_throttling"),
@@ -162,7 +186,7 @@ func TestThrottler_ThrottleError(t *testing.T) {
 			if err := th.ThrottleError(tt.args.errObj); (err != nil) != tt.wantErr {
 				t.Errorf("Throttler.ThrottleError() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.name == "default" && !th.IsThrottled(tt.args.errObj) {
+			if tt.name == "default" && !th.IsThrottledOrGraced(tt.args.errObj) {
 				t.Errorf("Throttler.ThrottleError() error = %v, wantErr %v", errors.New("throttling failed"), tt.wantErr)
 			}
 			if !tt.wantErr {
@@ -229,6 +253,7 @@ func Test_isOverThrottleDuration(t *testing.T) {
 	type args struct {
 		cachedTime       string
 		throttleDuration int
+		graceDuration    int
 	}
 	tests := []struct {
 		name string
@@ -240,6 +265,7 @@ func Test_isOverThrottleDuration(t *testing.T) {
 			args: args{
 				cachedTime:       time.Now().Add(-3 * time.Minute).Format(time.RFC3339), // -3 minutes => pass 2 minutes durations
 				throttleDuration: 2,
+				graceDuration:    0,
 			},
 			want: true,
 		},
@@ -248,6 +274,7 @@ func Test_isOverThrottleDuration(t *testing.T) {
 			args: args{
 				cachedTime:       time.Now().Add(1 * time.Minute).Format(time.RFC3339), // 1 minute ahead of current < throtte duration 2
 				throttleDuration: 2,
+				graceDuration:    0,
 			},
 			want: false,
 		},
@@ -259,4 +286,44 @@ func Test_isOverThrottleDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_isOverGraceDuration(t *testing.T) {
+	type args struct {
+		cachedTime       string
+		throttleDuration int
+		graceDuration    int
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test_isOverGraceDuration_true",
+			args: args{
+				cachedTime:       time.Now().Add(-3 * time.Minute).Format(time.RFC3339), // -3 minutes => pass 2 minutes durations
+				throttleDuration: 0,
+				graceDuration:    2,
+			},
+			want: true,
+		},
+		{
+			name: "Test_isOverGraceDuration_false",
+			args: args{
+				cachedTime:       time.Now().Add(1 * time.Minute).Format(time.RFC3339), // 1 minute ahead of current < throtte duration 2
+				throttleDuration: 0,
+				graceDuration:    2,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOverGraceDuration(tt.args.cachedTime, tt.args.graceDuration); got != tt.want {
+				t.Errorf("isOverGraceDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
 }

--- a/throttler_test.go
+++ b/throttler_test.go
@@ -49,6 +49,8 @@ func TestNewThrottler(t *testing.T) {
 			os.Setenv("THROTTLE_DURATION", "8")
 			os.Setenv("GRACE_DURATION", "0")
 			os.Setenv("THROTTLE_DISKCACHE_DIR", "new_cache_dir")
+		} else if tt.name == "default" {
+			os.Setenv("GRACE_DURATION", "")
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewThrottler()

--- a/throttler_test.go
+++ b/throttler_test.go
@@ -304,18 +304,18 @@ func Test_isOverGraceDuration(t *testing.T) {
 		{
 			name: "Test_isOverGraceDuration_true",
 			args: args{
-				cachedTime:       time.Now().Add(-3 * time.Minute).Format(time.RFC3339), // -3 minutes => pass 2 minutes durations
+				cachedTime:       time.Now().Add(-5 * time.Second).Format(time.RFC3339), // 2 sec after grace duration is over
 				throttleDuration: 0,
-				graceDuration:    2,
+				graceDuration:    3,
 			},
 			want: true,
 		},
 		{
 			name: "Test_isOverGraceDuration_false",
 			args: args{
-				cachedTime:       time.Now().Add(1 * time.Minute).Format(time.RFC3339), // 1 minute ahead of current < throtte duration 2
+				cachedTime:       time.Now().Add(2 * time.Second).Format(time.RFC3339), // still 8 sec left for grace duration
 				throttleDuration: 0,
-				graceDuration:    2,
+				graceDuration:    10,
 			},
 			want: false,
 		},

--- a/throttler_test.go
+++ b/throttler_test.go
@@ -44,13 +44,13 @@ func TestNewThrottler(t *testing.T) {
 	for _, tt := range tests {
 		if tt.name == "change duration" {
 			os.Setenv("THROTTLE_DURATION", "7")
-			os.Setenv("GRACE_DURATION", "5")
+			os.Setenv("THROTTLE_GRACE_SECONDS", "5")
 		} else if tt.name == "change both" {
 			os.Setenv("THROTTLE_DURATION", "8")
-			os.Setenv("GRACE_DURATION", "0")
+			os.Setenv("THROTTLE_GRACE_SECONDS", "0")
 			os.Setenv("THROTTLE_DISKCACHE_DIR", "new_cache_dir")
 		} else if tt.name == "default" {
-			os.Setenv("GRACE_DURATION", "")
+			os.Setenv("THROTTLE_GRACE_SECONDS", "")
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewThrottler()


### PR DESCRIPTION
This is a feature to add support for grace duration in seconds. Once grace is set, alerts will be ignored until the seconds are over and then start working usually with throttling. The default for grace is 0 sec.